### PR TITLE
Separates pending txs from confirmed txs in the wallet view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6913,9 +6913,9 @@
       }
     },
     "gridplus-sdk": {
-      "version": "0.3.2-dev",
-      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-0.3.2-dev.tgz",
-      "integrity": "sha512-HEv9Vm4TNE+BmwcVChKKG8QMSzo0H9n/U6R997MRyH0HlNyJAawWf7Z7mAHqMu9rhyr/pB9Bm7F6gabfGt5YrA==",
+      "version": "0.3.3-dev",
+      "resolved": "https://registry.npmjs.org/gridplus-sdk/-/gridplus-sdk-0.3.3-dev.tgz",
+      "integrity": "sha512-e1RUPc0XH52hlYi23glGNzVCBwOXn288mBcuKkm4FeiixVAOKjIoV71UXoYFU0fTNA5Xt+uS6+n9ItqkBU7utA==",
       "requires": {
         "aes-js": "^3.1.1",
         "bs58": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bs58check": "^2.1.2",
     "buffer": "^5.4.3",
     "gridplus-react-crypto": "0.0.5",
-    "gridplus-sdk": "^0.3.2-dev",
+    "gridplus-sdk": "^0.3.3-dev",
     "gulp": "^4.0.2",
     "nanoid": "^2.1.10",
     "qrcode.react": "^1.0.0",


### PR DESCRIPTION
We were already fetching pending transactions, but they were ordered along with the confirmed ones by block height, so they were all getting dropped to the bottom of the list (`height=-1`). Now we separate the pending transactions in the Wallet view screen and also indicate what is pending.

Fixes #16 