### PR TITLE
Adds pagination to ETH transactions

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -49,6 +49,7 @@ class Main extends React.Component {
     this.fetchData = this.fetchData.bind(this);
     this.handleStateUpdate = this.handleStateUpdate.bind(this);
     this.refreshWallets = this.refreshWallets.bind(this);
+    this.handlePageTurn = this.handlePageTurn.bind(this);
 
     // Bind wrappers
     this.retry = this.retry.bind(this);
@@ -153,6 +154,11 @@ class Main extends React.Component {
         this.fetchAddresses(this.fetchData);
       }
     })
+  }
+
+  handlePageTurn(page) {
+    this.state.session.setPage(page);
+    this.fetchData();
   }
 
   handleMenuChange({key}) {
@@ -386,6 +392,7 @@ class Main extends React.Component {
     let walletTag = null;
     const size = this.isMobile() ? 'small' : 'default';
     const activeWallet = this.state.session.getActiveWallet();
+    
     if (activeWallet === null) {
       walletTag = ( 
         <Button type="danger" ghost onClick={this.refreshWallets} size={size}>No Active Wallet!</Button>
@@ -404,7 +411,7 @@ class Main extends React.Component {
 
     // Add the currency switch
     extra.push(
-      (<Select key="currency-select" defaultValue="ETH" onChange={this.handleCurrencyChange} size={size}>
+      (<Select key="currency-select" defaultValue={this.state.currency} onChange={this.handleCurrencyChange} size={size}>
         <Option value="ETH">ETH</Option>
         <Option value="BTC">BTC</Option>
       </Select>)
@@ -456,6 +463,7 @@ class Main extends React.Component {
                   tick={this.state.tick}
                   lastUpdated={this.state.lastUpdated}
                   stillSyncingAddresses={this.state.stillSyncingAddresses}
+                  pageTurnCb={this.handlePageTurn}
           />
         );
       case 'menu-receive':

--- a/src/components/wallet.js
+++ b/src/components/wallet.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import 'antd/dist/antd.css'
 import { Button, Avatar, Divider, Statistic, List, Row, Card, Icon, Tag, Spin} from 'antd';
+import { constants } from '../util/helpers'
 const GREEN = "#00FF00";
 const RED = "#FF0000";
 
@@ -220,6 +221,27 @@ class Wallet extends React.Component {
     }
   }
 
+  renderPages() {
+    // We only paginate results for ETH
+    if (this.props.currency !== 'ETH')
+      return;
+    const page = this.props.session.getPage();
+    return (
+      <center style={{margin: "20px 0 0 0"}}>
+        {page > 1 ? (
+          <Button onClick={() => {this.props.pageTurnCb(page-1)}}>
+            <Icon type="caret-left"/>
+          </Button>
+        ) : null}
+        {this.state.txs.length >= constants.PAGE_SIZE ? (
+          <Button onClick={() => { this.props.pageTurnCb(page+1)}}>
+            <Icon type="caret-right"/>
+          </Button>
+        ): null}
+      </center>
+    )
+  }
+
   render() {
     return (
       <div style={{width: this.getInnerWidth() - 10}}>
@@ -244,6 +266,7 @@ class Wallet extends React.Component {
         <Divider/>
         <Row>
           {this.renderList()}
+          {this.renderPages()}
         </Row>
       </div>
     )

--- a/src/sdk/sdkSession.js
+++ b/src/sdk/sdkSession.js
@@ -41,6 +41,9 @@ class SDKSession {
 
     // The type of Bitcoin addresses the lattice is currently providing us
     this.btcAddrType = null;
+
+    // Current page of results (transactions) for the wallet
+    this.page = 1; // (1-indexed)
   
     // Go time
     this.getStorage();
@@ -277,7 +280,7 @@ class SDKSession {
   }
 
   fetchData(currency, cb=()=>{}, switchToChange=false) {
-    fetchStateData(currency, this.addresses, (err, data) => {
+    fetchStateData(currency, this.addresses, this.page, (err, data) => {
       if (err) 
         return cb(err);
       if (data)
@@ -286,6 +289,14 @@ class SDKSession {
     })
   }
 
+  setPage(newPage=1) {
+    this.page = newPage;
+    this.worker.postMessage({ type: 'setPage', data: this.page });
+  }
+
+  getPage() {
+    return this.page;
+  }
 
   // Load a set of addresses based on the currency and also based on the current
   // list of addresses we hold. Note that we are operating under a specific walletUID.


### PR DESCRIPTION
This corresponds to an updated `gridplus-cloud-services` API, which
now requires a `page` param (default=1) for requesting ETH transactions.
When the page is updated, we send an updated request to get that
set of transctions, but no other state data changes.

Resolves #36