### PR TITLE
Fixes broken `max` button on Send page

### DIFF
--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -286,7 +286,7 @@ exports.buildBtcTxReq = function(recipient, btcValue, utxos, addrs, changeAddrs,
     })
 
     // Calculate the fee
-    let bytesUsed = getBtcNumTxBytes(numInputs+1);
+    let bytesUsed = getBtcNumTxBytes(numInputs);
     // If the fee tips us over our total value sum, add another utxo
     if ((bytesUsed * feeRate) + satValue > sum) {
         // There's a chance that we just eclipsed the number of inputs we could support.


### PR DESCRIPTION
The erroneous behavior was only related to BTC and was the result
of an off-by-one error in the transaction builder itself.
This commit also updates the `max` button logic to be a bit more readable
for both BTC and ETH.
Fixes #91