### PR TITLE
Handles the network URL param to find a type of Lattice

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -32,7 +32,7 @@ class Connect extends React.Component {
       this.setState({ isLoading: true, errMsg: null })
       // Call the connect function. Skip the loading screen so we don't
       // leave the landing page until we connect.
-      this.props.submitCb({deviceID, password}, false);
+      this.props.submitCb({deviceID, password, network: this.props.network}, false);
     }
   }
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -4,6 +4,7 @@ const constants = {
     DEFAULT_APP_NAME: 'GridPlus Web Wallet',
     ENV: process.env.REACT_APP_ENV || 'prod',
     BASE_SIGNING_URL: process.env.REACT_APP_BASE_SIGNING_URL || 'https://signing.gridpl.us',
+    BASE_MAINNET_SIGNING_URL: process.env.REACT_APP_BASE_MAINNET_SIGNING_URL || 'https://signing.gridpl.us',
     GRIDPLUS_CLOUD_API: process.env.REACT_APP_GRIDPLUS_CLOUD_API || 'https://pay.gridplus.io:3000',
     ROOT_STORE: process.env.REACT_APP_ROOT_STORE || 'gridplus',
     HARDENED_OFFSET: 0x80000000,


### PR DESCRIPTION
We were previously depending on the routing mechanism coming from the Lattice keyring module,
but we ran into an issue which revealed the brittleness of that.
For external connections, we only want to pop up the connection page anyway, after which
point the window closes. We should be doing the routing on this site rather than expecting
external tools to know how to route to development vs production Lattices.