### PR TITLE
Handles the network URL param to find a type of Lattice

### DIFF
--- a/src/sdk/sdkSession.js
+++ b/src/sdk/sdkSession.js
@@ -8,7 +8,7 @@ const ReactCrypto = require('gridplus-react-crypto').default;
 const DEVICE_ADDR_SYNC_MS = 2000; // It takes roughly 2000 to sync a new address
 
 class SDKSession {
-  constructor(deviceID, stateUpdateHandler, name=null) {
+  constructor(deviceID, stateUpdateHandler, name=null, network=null) {
     this.client = null;
     this.crypto = null;
     this.name = name || 'GridPlus Web Wallet'; // app name
@@ -24,6 +24,8 @@ class SDKSession {
     // Cached list of unused addresses. These indicate the next available
     // address for each currency. Currently only contains a Bitcoin address
     this.firstUnusedAddresses = {};
+    // Network is used to determine how to contact the Lattice, if applicable
+    this.network = network;
 
     // Make use of localstorage to persist wallet data
     this.storageSession = null;
@@ -476,6 +478,20 @@ class SDKSession {
     // enter a reasonably strong password to prevent unwanted requests
     // from nefarious actors.
     const key = this._genPrivKey(deviceID, pw, this.name);
+    // Determine if we need to contact production Lattices
+    let baseUrl = constants.BASE_SIGNING_URL;
+    switch (this.network) {
+      case 'rpc':
+      case 'mainnet':
+        baseUrl = constants.BASE_MAINNET_SIGNING_URL;
+        break;
+      case 'rinkeby':
+        baseUrl = constants.BASE_RINKEBY_SIGNING_URL;
+        break;
+      default:
+        break; 
+    }
+    
     // If no client exists in this session, create a new one and
     // attach it.
     let client;
@@ -484,7 +500,7 @@ class SDKSession {
         name: this.name,
         crypto: this.crypto,
         privKey: key,
-        baseUrl: constants.BASE_SIGNING_URL,
+        baseUrl,
         timeout: tmpTimeout, // Artificially short timeout for simply locating the Lattice
       })
     } catch (err) {

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -4,6 +4,8 @@ const constants = {
     DEFAULT_APP_NAME: 'GridPlus Web Wallet',
     ENV: process.env.REACT_APP_ENV || 'prod',
     BASE_SIGNING_URL: process.env.REACT_APP_BASE_SIGNING_URL || 'https://signing.gridpl.us',
+    BASE_MAINNET_SIGNING_URL: process.env.REACT_APP_BASE_MAINNET_SIGNING_URL || 'https://signing.gridpl.us',
+    BASE_RINKEBY_SIGNING_URL: process.env.REACT_APP_BASE_RINKEBY_SIGNING_URL || 'https://signing.staging-gridpl.us',
     GRIDPLUS_CLOUD_API: process.env.REACT_APP_GRIDPLUS_CLOUD_API || 'https://pay.gridplus.io:3000',
     ROOT_STORE: process.env.REACT_APP_ROOT_STORE || 'gridplus',
     HARDENED_OFFSET: 0x80000000,


### PR DESCRIPTION
We were previously depending on the routing mechanism coming from the Lattice keyring module,
but we ran into an issue which revealed the brittleness of that.
For external connections, we only want to pop up the connection page anyway, after which
point the window closes. We should be doing the routing on this site rather than expecting
external tools to know how to route to development vs production Lattices.