### PR TITLE
Export custom endpoint

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -4,7 +4,7 @@ import './styles.css'
 import { Alert, Button, Layout, Menu, Icon, Select, PageHeader, Tag, Tooltip } from 'antd';
 import { default as SDKSession } from '../sdk/sdkSession';
 import { Connect, Error, Loading, Pair, Permissions, Send, Receive, Wallet, EthContracts, Settings } from './index'
-import { constants, getCurrencyText, setEthersProvider } from '../util/helpers'
+import { constants, getCurrencyText, setEthersProvider, getLocalStorageSettings } from '../util/helpers'
 const { Content, Footer, Sider } = Layout;
 const { Option } = Select;
 
@@ -218,7 +218,13 @@ class Main extends React.Component {
     const data = {
       deviceID: this.state.deviceID,
       password: this.state.password,
+      endpoint: constants.BASE_SIGNING_URL,
     };
+    // Check if there is a custom endpoint configured
+    const settings = getLocalStorageSettings();
+    if (settings.customEndpoint && settings.customEndpoint !== '') {
+      data.endpoint = settings.customEndpoint;
+    }
     this.handleLogout();
     window.opener.postMessage(JSON.stringify(data), "*");
     window.close();

--- a/src/components/settings.js
+++ b/src/components/settings.js
@@ -2,7 +2,7 @@ import React from 'react';
 import 'antd/dist/antd.css'
 import { Button, Card, Col, Collapse, Icon, Input, Row, Switch, Table } from 'antd'
 import './styles.css'
-import { constants, } from '../util/helpers';
+import { constants, getLocalStorageSettings } from '../util/helpers';
 const settingsPath = `${constants.ROOT_STORE}/settings`
 
 class Settings extends React.Component {
@@ -25,8 +25,7 @@ class Settings extends React.Component {
   }
 
   getSettings() {
-    const storage = JSON.parse(window.localStorage.getItem(constants.ROOT_STORE) || '{}');
-    const settings = storage.settings ? storage.settings : {};
+    const settings = getLocalStorageSettings();
     this.setState({ settings })
   }
 

--- a/src/util/helpers.js
+++ b/src/util/helpers.js
@@ -232,6 +232,19 @@ exports.fetchStateData = function(currency, addresses, page, cb) {
 //--------------------------------------------
 
 //--------------------------------------------
+// LOCAL STORAGE HELPERS
+//--------------------------------------------
+exports.getLocalStorageSettings = function() {
+    const storage = JSON.parse(window.localStorage.getItem(constants.ROOT_STORE) || '{}');
+    const settings = storage.settings ? storage.settings : {};
+    return settings;
+}
+
+//--------------------------------------------
+// END LOCAL STORAGE HELPERS
+//--------------------------------------------
+
+//--------------------------------------------
 // OTHER HELPERS
 //--------------------------------------------
 exports.harden = function(x) {


### PR DESCRIPTION
We were previously not returning the custom endpoint to the keyring requester, which meant the origin was unable to make requests on the desired channel and just fell back to the default. This PR adds a mechanism to return the custom endpoint configured in settings, if one exists, to the keyring origin.